### PR TITLE
Handle errors in Task callbacks

### DIFF
--- a/can-wait.js
+++ b/can-wait.js
@@ -163,7 +163,14 @@ Request.prototype.run = function(fn, ctx, args){
 Request.prototype.runWithinScope = function(fn, ctx, args){
 	waitWithinRequest.currentRequest = this;
 	this.trap();
-	var res = fn.apply(ctx, args);
+	var res;
+
+	try {
+		res = fn.apply(ctx, args);
+	} catch(err) {
+		this.errors.push(err);
+	}
+
 	this.release();
 	return res;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,21 @@ QUnit.test("XHR errors are returned", function(){
 	QUnit.stop();
 });
 
+QUnit.test("Rejects when an error occurs in a setTimeout callback", function(){
+	var waits = 0;
+
+	canWait(function(){
+		setTimeout(function(){
+			throw new Error("ha ha");
+		}, 20);
+	}).then(null, function(errors){
+		QUnit.equal(errors.length, 1, "There was one error");
+		QUnit.equal(errors[0].message, "ha ha", "Same error object");
+	}).then(QUnit.start);
+
+	QUnit.stop();
+});
+
 QUnit.module("nested setTimeouts", {
 	beforeEach: function(test){
 		var results = this.results = [];


### PR DESCRIPTION
Any task could cause an Error by throwing an exception. This handles
those by wrapping task function calls in a try/catch and then pushes
errors to the errors callback. Closes #4