### PR TITLE
Correctly handle for when outside of a request

### DIFF
--- a/can-wait.js
+++ b/can-wait.js
@@ -19,6 +19,7 @@ function Deferred(){
 
 var waitWithinRequest = g.canWait = function(fn, catchErrors){
 	var request = waitWithinRequest.currentRequest;
+	if(!request) return fn;
 	request.waits++;
 
 	return function(){
@@ -28,6 +29,7 @@ var waitWithinRequest = g.canWait = function(fn, catchErrors){
 
 waitWithinRequest.data = function(dataOrPromise){
 	var request = waitWithinRequest.currentRequest;
+	if(!request) return dataOrPromise;
 	var save = function(data){
 		request.responses.push(data);
 		return data;
@@ -161,6 +163,7 @@ Request.prototype.release = function(){
 };
 
 Request.prototype.end = function(){
+	waitWithinRequest.currentRequest = undefined;
 	var dfd = this.deferred;
 	if(this.errors.length) {
 		dfd.reject(this.errors);

--- a/test/test.js
+++ b/test/test.js
@@ -246,3 +246,21 @@ describe("canWait.data", function(){
 		}).then(done);
 	});
 });
+
+describe("outside of request lifecycle", function(){
+	it("there is no currentRequest", function(){
+		assert.equal(canWait.currentRequest, undefined,
+					 "since we are not within a request there is no " +
+						 "currentRequest");
+	});
+
+	it("calling canWait returns back the function passed", function(){
+		var fn = function(){};
+		assert.equal(canWait(fn), fn, "Same function");
+	});
+
+	it("calling canWait.data returns back the data", function(){
+		var data = {};
+		assert.equal(canWait.data(data), data, "Same data");
+	});
+});


### PR DESCRIPTION
When not processing a request (when wait() is not being called) the
global `canWait` still exists, so anything that calls that needs to
simply get their original function back.

Fixes #11 and #12