### PR TITLE
Correctly handle nested requests

### DIFF
--- a/can-wait.js
+++ b/can-wait.js
@@ -149,6 +149,8 @@ function Request() {
 }
 
 Request.prototype.trap = function(){
+	this.previousRequest = waitWithinRequest.currentRequest;
+	waitWithinRequest.currentRequest = this;
 	var o = this.overrides;
 	for(var i = 0, len = o.length; i < len; i++) {
 		o[i].trap();
@@ -160,10 +162,11 @@ Request.prototype.release = function(){
 	for(var i = 0, len = o.length; i < len; i++) {
 		o[i].release();
 	}
+	waitWithinRequest.currentRequest = this.previousRequest;
+	waitWithinRequest.previousRequest = undefined;
 };
 
 Request.prototype.end = function(){
-	waitWithinRequest.currentRequest = undefined;
 	var dfd = this.deferred;
 	if(this.errors.length) {
 		dfd.reject(this.errors);
@@ -191,7 +194,6 @@ Request.prototype.run = function(fn, ctx, args, catchErrors){
 };
 
 Request.prototype.runWithinScope = function(fn, ctx, args, catchErrors){
-	waitWithinRequest.currentRequest = this;
 	this.trap();
 
 	var res;

--- a/test/test.js
+++ b/test/test.js
@@ -264,3 +264,22 @@ describe("outside of request lifecycle", function(){
 		assert.equal(canWait.data(data), data, "Same data");
 	});
 });
+
+describe("nested requests", function(){
+	it("calling canWait.data passes data to the correct request", function(done){
+		wait(function(){
+			wait(function(){
+				setTimeout(function(){
+					canWait.data({ hello: "world" });
+				}, 20);
+			}).then(function(responses){
+				responses.forEach(function(r){
+					canWait.data(r);
+				});
+			});
+		}).then(function(responses){
+			assert.equal(responses.length, 1, "got back a response");
+			assert.equal(responses[0].hello, "world", "correct response");
+		}).then(done, done);
+	});
+});


### PR DESCRIPTION
Requests can be nested, so we need to be able to handle that. The way we
can handle it is each time we execute the Task we set the
`previousRequest` in a variable and reset it back at the end of Task,
	this way the `canWait.currentRequest` is always pointing to the
	correct place, regardless of nesting.