### PR TITLE
Implements can-wait/waitfor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For can-wait to work we have to override various task-creating functionality, th
 
 * requestAnimationFrame
 * Promise
+* process.nextTick
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ wait(function(){
 });
 ```
 
+### canWait.error
+
+Like **canWait.data** but pushes an error into the errors array for the current request. Most likely you can just throw an error to have it propagate, this is only useful in limited scenarios.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ npm install can-wait --save
 ## Usage
 
 ```js
-var wait = require("can-wait");
+import wait from "can-wait";
+import { waitData } from "can-wait/waitfor";
 
 wait(function(){
 
 	setTimeout(function(){
-		canWait.data("a");
+		waitData("a");
 	}, 29);
 
 	setTimeout(function(){
-		canWait.data("b");
+		waitData("b");
 	}, 13);
 
 	var xhr = new XMLHttpRequest();
 	xhr.open("GET", "http://chat.donejs.com/api/messages");
 	xhr.onload = function(){
-		canWait.data("c");
+		waitData("c");
 	};
 	xhr.send();
 
@@ -72,19 +73,34 @@ fs.readFile("some/file", canWait(function(err, file){
 }));
 ```
 
-### canWait
+### waitFor
 
-**canWait** is a function that creates a callback that can be used with any async functionality. Calling canWait registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
+**waitFor** is a function that creates a callback that can be used with any async functionality. Calling waitFor registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
 
-### canWait.data
-
-You might want to get data back from can-wait, for example if you are using the library to track asynchronous rendering requests. Calling **canWait.data** with data or a Promise will register that data within the current request.
+This is useful if there is async functionality other than what [we implement](#tasks). You might be using a library that has C++ bindings and doesn't go through the normal JavaScript async APIs.
 
 ```js
-var xhr = new XMLHttpRequest();
+import waitFor from "can-wait/waitfor";
+import asyncThing from "some-module-that-does-secret-async-stuff";
+
+asyncThing(waitFor(function(){
+	// We waited on this!
+}));
+```
+
+### waitData
+
+You might want to get data back from can-wait, for example if you are using the library to track asynchronous rendering requests. Calling **waitData** with data or a Promise will register that data within the current request.
+
+```js
+import { waitFor, waitData } from "can-wait/waitfor";
+
+// Note that waitData === waitFor.data === waitFor.waitData
+
+let xhr = new XMLHttpRequest();
 xhr.open("GET", "http://example.com");
 xhr.onload = function(){
-	canWait.data(xhr.responseText);
+	waitData(xhr.responseText);
 };
 xhr.send();
 ```
@@ -96,25 +112,40 @@ var promise = $.ajax({
 	url: "http://example.com"
 });
 
-canWait.data(promise);
+waitData(promise);
 ```
 
-The data you register with **canWait.data** will be returned from the Promise as an array:
+The data you register with **waitData** will be returned from the Promise as an array:
 
 ```js
-var wait = require("can-wait");
+import wait from "can-wait";
 
 wait(function(){
-	doSomeXHRThatCallsCanWaitData();
+	doSomeXHRThatCallsWaitData();
 })
 .then(function(responses){
 	console.log(responses); // -> [{ foo: 'bar' }]
 });
 ```
 
-### canWait.error
+### waitError
 
-Like **canWait.data** but pushes an error into the errors array for the current request. Most likely you can just throw an error to have it propagate, this is only useful in limited scenarios.
+Like **waitData** but pushes an error into the errors array for the current request. Most likely you can just throw an error to have it propagate, this is only useful in limited scenarios.
+
+```js
+import { waitError } from "can-wait/waitfor";
+import wait from "can-wait";
+
+wait(function(){
+
+	setTimeout(function(){
+		waitError(new Error("oh no"));
+	}, 100);
+
+}).then(null, function(errors){
+	errors; // -> [{message: "oh no"}]
+});
+```
 
 ## License
 

--- a/can-wait.js
+++ b/can-wait.js
@@ -40,6 +40,13 @@ waitWithinRequest.data = waitWithinRequest.data || function(dataOrPromise){
 	return save(dataOrPromise);
 };
 
+waitWithinRequest.error = waitWithinRequest.error || function(error){
+	var request = waitWithinRequest.currentRequest;
+	if(!request) return error;
+	request.errors.push(error);
+	return error;
+};
+
 function Override(obj, name, fn) {
 	this.old = obj[name];
 	this.obj = obj;

--- a/can-wait.js
+++ b/can-wait.js
@@ -7,6 +7,8 @@ var g = typeof WorkerGlobalScope !== "undefined" && (self instanceof WorkerGloba
 // Keep a local reference since we will be overriding this later.
 var Promise = g.Promise;
 
+var slice = Array.prototype.slice;
+
 function Deferred(){
 	var dfd = this;
 	this.promise = new Promise(function(resolve, reject){
@@ -135,7 +137,22 @@ var allOverrides = [
 				return send.apply(this, arguments);
 			};
 		});
+	},
+
+	function(request){
+		return typeof process === "undefined" || !process.nextTick ?
+			undefined :
+
+		new Override(process, "nextTick", function(nextTick){
+			return function(fn/*, ...args */){
+				var callback = waitWithinRequest(fn);
+				var args = slice.call(arguments, 1);
+				args.unshift(callback);
+				return nextTick.apply(process, args);
+			};
+		});
 	}
+
 ];
 
 

--- a/can-wait.js
+++ b/can-wait.js
@@ -17,7 +17,7 @@ function Deferred(){
 	});
 }
 
-var waitWithinRequest = g.canWait = function(fn, catchErrors){
+var waitWithinRequest = g.canWait = g.canWait || function(fn, catchErrors){
 	var request = waitWithinRequest.currentRequest;
 	if(!request) return fn;
 	request.waits++;
@@ -27,7 +27,7 @@ var waitWithinRequest = g.canWait = function(fn, catchErrors){
 	};
 };
 
-waitWithinRequest.data = function(dataOrPromise){
+waitWithinRequest.data = waitWithinRequest.data || function(dataOrPromise){
 	var request = waitWithinRequest.currentRequest;
 	if(!request) return dataOrPromise;
 	var save = function(data){

--- a/can-wait.js
+++ b/can-wait.js
@@ -7,8 +7,6 @@ var g = typeof WorkerGlobalScope !== "undefined" && (self instanceof WorkerGloba
 // Keep a local reference since we will be overriding this later.
 var Promise = g.Promise;
 
-var has = Object.prototype.hasOwnProperty;
-
 function Deferred(){
 	var dfd = this;
 	this.promise = new Promise(function(resolve, reject){
@@ -82,7 +80,7 @@ var allOverrides = [
 	},
 
 	function(request) {
-		return new Override(Promise.prototype, "then", function(then){
+		return new Override(g.Promise.prototype, "then", function(then){
 			return function(onFulfilled, onRejected){
 				var fn;
 				var callback = waitWithinRequest(function(){
@@ -156,7 +154,7 @@ function Request() {
 }
 
 Request.prototype.trap = function(){
-	this.previousRequest = waitWithinRequest.currentRequest;
+	waitWithinRequest.previousRequest = waitWithinRequest.currentRequest;
 	waitWithinRequest.currentRequest = this;
 	var o = this.overrides;
 	for(var i = 0, len = o.length; i < len; i++) {
@@ -169,7 +167,7 @@ Request.prototype.release = function(){
 	for(var i = 0, len = o.length; i < len; i++) {
 		o[i].release();
 	}
-	waitWithinRequest.currentRequest = this.previousRequest;
+	waitWithinRequest.currentRequest = waitWithinRequest.previousRequest;
 	waitWithinRequest.previousRequest = undefined;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-wait",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Asynchronous render for all frameworks",
   "main": "can-wait.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-wait",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Asynchronous render for all frameworks",
   "main": "can-wait.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-wait",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Asynchronous render for all frameworks",
   "main": "can-wait.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-wait",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Asynchronous render for all frameworks",
   "main": "can-wait.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-wait",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Asynchronous render for all frameworks",
   "main": "can-wait.js",
   "scripts": {

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
 <title>can-wait tests</title>
 <meta charset="UTF-8">
-<script src="../node_modules/steal/steal.js" main="test/test" data-mocha="bdd"></script>
+<script src="../node_modules/steal/steal.js" main="test/test_browser"
+	data-mocha="bdd" data-transpiler="babel"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -323,3 +323,18 @@ describe("nested requests", function(){
 		}).then(done, done);
 	});
 });
+
+if(isNode) {
+	describe("process.nextTick", function(){
+		it("works", function(done){
+			wait(function(){
+				process.nextTick(function(){
+					canWait.data("hello");
+				});
+			}).then(function(responses){
+				assert.equal(responses.length, 1, "there is one result");
+			})
+			.then(done, done);
+		});
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -228,6 +228,28 @@ describe("Promises", function(){
 	});
 });
 
+describe("canWait", function(){
+	it("caughtErrors=false will not try and catch errors", function(done){
+		wait(function(){
+			Promise.resolve().then(function(){
+				var caught = canWait(function(){
+					throw new Error("ahh!");
+				});
+				caught();
+			}).then(function(){
+				var notCaught = canWait(function(){
+					throw new Error("oh no");
+				}, false);
+
+				notCaught();
+			}).then(null, function(){});
+		}).then(null, function(errors){
+			assert.equal(errors.length, 1, "There was 1 error");
+			assert(!canWait.currentRequest, "There is no current request");
+		}).then(done, done);
+	});
+});
+
 describe("canWait.data", function(){
 	it("Calling canWait.data returns data in the Promise", function(done){
 		wait(function(){

--- a/test/test.js
+++ b/test/test.js
@@ -247,6 +247,19 @@ describe("canWait.data", function(){
 	});
 });
 
+describe("canWait.error", function(){
+	it("calling canWait.error adds an error to the current request", function(done){
+		wait(function(){
+			setTimeout(function(){
+				canWait.error(new Error("hey there"));
+			}, 200);
+		}).then(null, function(errors){
+			assert.equal(errors.length, 1, "there was one error");
+			assert.equal(errors[0].message, "hey there", "it was the correct error");
+		}).then(done, done);
+	});
+});
+
 describe("outside of request lifecycle", function(){
 	it("there is no currentRequest", function(){
 		assert.equal(canWait.currentRequest, undefined,
@@ -262,6 +275,11 @@ describe("outside of request lifecycle", function(){
 	it("calling canWait.data returns back the data", function(){
 		var data = {};
 		assert.equal(canWait.data(data), data, "Same data");
+	});
+
+	it("calling canWait.error returns back the error", function(){
+		var error = new Error("oh no");
+		assert.equal(canWait.error(error).message, "oh no", "Same error");
 	});
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -338,3 +338,7 @@ if(isNode) {
 		});
 	});
 }
+
+
+// Require other things
+require("./waitfor-cjs");

--- a/test/test_browser.js
+++ b/test/test_browser.js
@@ -1,0 +1,2 @@
+require("./test");
+require("./waitfor-es6");

--- a/test/waitfor-cjs.js
+++ b/test/waitfor-cjs.js
@@ -1,0 +1,10 @@
+var wait = require("../can-wait");
+var waitFor = require("../waitfor");
+var waitData = waitFor.waitData;
+var waitError = waitFor.waitError;
+var assert = require("assert");
+var test = require("./waitfor_test");
+
+describe("can-wait/waitfor CommonJS", function(){
+	test(wait, assert, waitFor, waitData, waitError);
+});

--- a/test/waitfor-es6.js
+++ b/test/waitfor-es6.js
@@ -1,0 +1,16 @@
+import wait from "../can-wait";
+import waitFor, { waitData, waitFor as otherWaitFor, waitError } from "../waitfor";
+import assert from "assert";
+import test from './waitfor_test';
+
+describe("can-wait/waitfor es6", function(){
+	describe("ES6 API", function(){
+		it("All of the things are right", function(){
+			assert.equal(waitFor, otherWaitFor, "These are just aliases");
+			assert.equal(waitData, waitFor.data, "waitData as waitFor.data");
+			assert.equal(waitData, waitFor.waitData, "waitData as waitFor.waitData");
+		});
+	});
+
+	test(wait, assert, waitFor, waitData, waitError);
+});

--- a/test/waitfor_test.js
+++ b/test/waitfor_test.js
@@ -1,0 +1,43 @@
+module.exports = tests;
+
+function tests(wait, assert, waitFor, waitData, waitError) {
+
+	describe("waitFor", function(){
+		it("Does wait on stuff", function(done){
+			wait(function(){
+				Promise.resolve().then(waitFor(function(){
+					assert(true, "we did wait for this");
+				}));
+			}).then(done, done);
+		});
+	});
+
+	describe("waitData", function(){
+		it("Adds data to a request", function(done){
+			wait(function(){
+				setTimeout(function(){
+					waitData("hello world");
+				}, 40);
+			}).then(function(responses){
+				assert.equal(responses.length, 1, "One piece of data added");
+				assert.equal(responses[0], "hello world", "data added to the request");
+			}).then(done, done);
+		});
+	});
+
+	describe("waitError", function(){
+		it("adds errors to the error stack", function(done){
+			wait(function(){
+				setTimeout(function(){
+					var error = new Error("oh no");
+					var ret = waitError(error);
+					assert.equal(error, ret, "waitError returns the error");
+				}, 20);
+			}).then(null, function(errors){
+				assert.equal(errors.length, 1, "There is one error in the stack");
+				assert.equal(errors[0].message, "oh no", "Correct error");
+			}).then(done, done);
+		});
+	});
+
+}

--- a/waitfor.js
+++ b/waitfor.js
@@ -1,0 +1,33 @@
+
+var waitFor = exports["default"] = exports.waitFor = function(fn){
+	if(canWaitPresent()) {
+		return canWait.apply(this, arguments);
+	}
+	return fn;
+};
+
+// ES6
+exports.__useDefault = true;
+exports.__esModule = true;
+
+exports.waitData = exports.data = waitFor.waitData = waitFor.data = function(data){
+	if(canWaitPresent()) {
+		return canWait.data.apply(canWait, arguments);
+	}
+	return data;
+};
+
+exports.waitError = exports.error = waitFor.waitError = waitFor.error = function(error){
+	if(canWaitPresent()) {
+		return canWait.error.apply(canWait, arguments);
+	}
+	return error;
+};
+
+function canWaitPresent(){
+	return typeof canWait !== "undefined" && !!canWait.data;
+}
+
+if(typeof steal === "undefined") {
+	module.exports = waitFor;
+}


### PR DESCRIPTION
This adds a new module can-wait/waitfor.  This is a simple wrapper
around the globals `canWait` and `canWait.data`. This prevents the need
to detect of canWait exists, you can just use this and if it exists it
will be called, otherwise it's a noop. Closes #22