### PR TITLE
Implements can-wait/waitfor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ npm install can-wait --save
 ## Usage
 
 ```js
-var wait = require("can-wait");
+import wait from "can-wait";
+import { waitData } from "can-wait/waitfor";
 
 wait(function(){
 
 	setTimeout(function(){
-		canWait.data("a");
+		waitData("a");
 	}, 29);
 
 	setTimeout(function(){
-		canWait.data("b");
+		waitData("b");
 	}, 13);
 
 	var xhr = new XMLHttpRequest();
 	xhr.open("GET", "http://chat.donejs.com/api/messages");
 	xhr.onload = function(){
-		canWait.data("c");
+		waitData("c");
 	};
 	xhr.send();
 
@@ -72,19 +73,34 @@ fs.readFile("some/file", canWait(function(err, file){
 }));
 ```
 
-### canWait
+### waitFor
 
-**canWait** is a function that creates a callback that can be used with any async functionality. Calling canWait registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
+**waitFor** is a function that creates a callback that can be used with any async functionality. Calling waitFor registers a wait with the currently running request and returns a function that, when called, will decrement the wait count.
 
-### canWait.data
-
-You might want to get data back from can-wait, for example if you are using the library to track asynchronous rendering requests. Calling **canWait.data** with data or a Promise will register that data within the current request.
+This is useful if there is async functionality other than what [we implement](#tasks). You might be using a library that has C++ bindings and doesn't go through the normal JavaScript async APIs.
 
 ```js
-var xhr = new XMLHttpRequest();
+import waitFor from "can-wait/waitfor";
+import asyncThing from "some-module-that-does-secret-async-stuff";
+
+asyncThing(waitFor(function(){
+	// We waited on this!
+}));
+```
+
+### waitData
+
+You might want to get data back from can-wait, for example if you are using the library to track asynchronous rendering requests. Calling **waitData** with data or a Promise will register that data within the current request.
+
+```js
+import { waitFor, waitData } from "can-wait/waitfor";
+
+// Note that waitData === waitFor.data === waitFor.waitData
+
+let xhr = new XMLHttpRequest();
 xhr.open("GET", "http://example.com");
 xhr.onload = function(){
-	canWait.data(xhr.responseText);
+	waitData(xhr.responseText);
 };
 xhr.send();
 ```
@@ -96,25 +112,40 @@ var promise = $.ajax({
 	url: "http://example.com"
 });
 
-canWait.data(promise);
+waitData(promise);
 ```
 
-The data you register with **canWait.data** will be returned from the Promise as an array:
+The data you register with **waitData** will be returned from the Promise as an array:
 
 ```js
-var wait = require("can-wait");
+import wait from "can-wait";
 
 wait(function(){
-	doSomeXHRThatCallsCanWaitData();
+	doSomeXHRThatCallsWaitData();
 })
 .then(function(responses){
 	console.log(responses); // -> [{ foo: 'bar' }]
 });
 ```
 
-### canWait.error
+### waitError
 
-Like **canWait.data** but pushes an error into the errors array for the current request. Most likely you can just throw an error to have it propagate, this is only useful in limited scenarios.
+Like **waitData** but pushes an error into the errors array for the current request. Most likely you can just throw an error to have it propagate, this is only useful in limited scenarios.
+
+```js
+import { waitError } from "can-wait/waitfor";
+import wait from "can-wait";
+
+wait(function(){
+
+	setTimeout(function(){
+		waitError(new Error("oh no"));
+	}, 100);
+
+}).then(null, function(errors){
+	errors; // -> [{message: "oh no"}]
+});
+```
 
 ## License
 

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
 <title>can-wait tests</title>
 <meta charset="UTF-8">
-<script src="../node_modules/steal/steal.js" main="test/test" data-mocha="bdd"></script>
+<script src="../node_modules/steal/steal.js" main="test/test_browser"
+	data-mocha="bdd" data-transpiler="babel"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -338,3 +338,7 @@ if(isNode) {
 		});
 	});
 }
+
+
+// Require other things
+require("./waitfor-cjs");

--- a/test/test_browser.js
+++ b/test/test_browser.js
@@ -1,0 +1,2 @@
+require("./test");
+require("./waitfor-es6");

--- a/test/waitfor-cjs.js
+++ b/test/waitfor-cjs.js
@@ -1,0 +1,10 @@
+var wait = require("../can-wait");
+var waitFor = require("../waitfor");
+var waitData = waitFor.waitData;
+var waitError = waitFor.waitError;
+var assert = require("assert");
+var test = require("./waitfor_test");
+
+describe("can-wait/waitfor CommonJS", function(){
+	test(wait, assert, waitFor, waitData, waitError);
+});

--- a/test/waitfor-es6.js
+++ b/test/waitfor-es6.js
@@ -1,0 +1,16 @@
+import wait from "../can-wait";
+import waitFor, { waitData, waitFor as otherWaitFor, waitError } from "../waitfor";
+import assert from "assert";
+import test from './waitfor_test';
+
+describe("can-wait/waitfor es6", function(){
+	describe("ES6 API", function(){
+		it("All of the things are right", function(){
+			assert.equal(waitFor, otherWaitFor, "These are just aliases");
+			assert.equal(waitData, waitFor.data, "waitData as waitFor.data");
+			assert.equal(waitData, waitFor.waitData, "waitData as waitFor.waitData");
+		});
+	});
+
+	test(wait, assert, waitFor, waitData, waitError);
+});

--- a/test/waitfor_test.js
+++ b/test/waitfor_test.js
@@ -1,0 +1,43 @@
+module.exports = tests;
+
+function tests(wait, assert, waitFor, waitData, waitError) {
+
+	describe("waitFor", function(){
+		it("Does wait on stuff", function(done){
+			wait(function(){
+				Promise.resolve().then(waitFor(function(){
+					assert(true, "we did wait for this");
+				}));
+			}).then(done, done);
+		});
+	});
+
+	describe("waitData", function(){
+		it("Adds data to a request", function(done){
+			wait(function(){
+				setTimeout(function(){
+					waitData("hello world");
+				}, 40);
+			}).then(function(responses){
+				assert.equal(responses.length, 1, "One piece of data added");
+				assert.equal(responses[0], "hello world", "data added to the request");
+			}).then(done, done);
+		});
+	});
+
+	describe("waitError", function(){
+		it("adds errors to the error stack", function(done){
+			wait(function(){
+				setTimeout(function(){
+					var error = new Error("oh no");
+					var ret = waitError(error);
+					assert.equal(error, ret, "waitError returns the error");
+				}, 20);
+			}).then(null, function(errors){
+				assert.equal(errors.length, 1, "There is one error in the stack");
+				assert.equal(errors[0].message, "oh no", "Correct error");
+			}).then(done, done);
+		});
+	});
+
+}

--- a/waitfor.js
+++ b/waitfor.js
@@ -1,0 +1,33 @@
+
+var waitFor = exports["default"] = exports.waitFor = function(fn){
+	if(canWaitPresent()) {
+		return canWait.apply(this, arguments);
+	}
+	return fn;
+};
+
+// ES6
+exports.__useDefault = true;
+exports.__esModule = true;
+
+exports.waitData = exports.data = waitFor.waitData = waitFor.data = function(data){
+	if(canWaitPresent()) {
+		return canWait.data.apply(canWait, arguments);
+	}
+	return data;
+};
+
+exports.waitError = exports.error = waitFor.waitError = waitFor.error = function(error){
+	if(canWaitPresent()) {
+		return canWait.error.apply(canWait, arguments);
+	}
+	return error;
+};
+
+function canWaitPresent(){
+	return typeof canWait !== "undefined" && !!canWait.data;
+}
+
+if(typeof steal === "undefined") {
+	module.exports = waitFor;
+}


### PR DESCRIPTION
This adds a new module can-wait/waitfor.  This is a simple wrapper
around the globals `canWait` and `canWait.data`. This prevents the need
to detect of canWait exists, you can just use this and if it exists it
will be called, otherwise it's a noop. Closes #22