### PR TITLE
Allow passing in Overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,29 @@ wait(function(){
 });
 ```
 
+### Custom overrides
+
+By default can-wait overrides all of the tasks listed in the [#tasks](Tasks) section, but you might also want to override additional globals. You can do that using the waitOptions object:
+
+#### waitOptions
+
+Additional options provided to the wait request:
+
+```js
+import wait from "can-wait";
+const Override = wait.Override;
+
+wait(fn, {
+	overrides: [
+			function(request){
+					return new Override(global, "prop", function(prop){
+							return replacement;
+					});
+			}
+	]
+});
+```
+
 ## License
 
 MIT

--- a/can-wait.js
+++ b/can-wait.js
@@ -62,6 +62,8 @@ Override.prototype.release = function(){
 	this.obj[this.name] = this.old;
 };
 
+canWait.Override = Override;
+
 var allOverrides = [
 	function(request){
 		return new Override(g, "setTimeout", function(setTimeout){
@@ -156,15 +158,18 @@ var allOverrides = [
 ];
 
 
-function Request() {
+function Request(options) {
 	this.deferred = new Deferred();
 	this.waits = 0;
 	this.errors = [];
 	this.responses = [];
 	var o = this.overrides = [], def;
 
-	for(var i = 0, len = allOverrides.length; i < len; i++) {
-		def = allOverrides[i](this);
+	var localOverrides = ((options && options.overrides)||[])
+		.concat(allOverrides);
+
+	for(var i = 0, len = localOverrides.length; i < len; i++) {
+		def = localOverrides[i](this);
 		if(def)
 			o.push(def);
 	}
@@ -234,8 +239,8 @@ Request.prototype.runWithinScope = function(fn, ctx, args, catchErrors){
 	return res;
 };
 
-function canWait(fn) {
-	var request = new Request();
+function canWait(fn, options) {
+	var request = new Request(options);
 
 	// Call the function
 	request.runWithinScope(fn);

--- a/test/test.js
+++ b/test/test.js
@@ -339,6 +339,29 @@ if(isNode) {
 	});
 }
 
+describe("Options", function(){
+	it("overrides work", function(done){
+		var Override = wait.Override;
+		var myFoo = {};
+
+		var waitOptions = {
+			overrides: [
+				function(){
+					return new Override(g, "FOO", function() { return myFoo; });
+				}
+			]
+		};
+
+		wait(function(){
+			setTimeout(function(){
+				assert.equal(FOO, myFoo, "Global was overwritten");
+			}, 10);
+		}, waitOptions).then(done, function(errors){
+			done(errors[0]);
+		});
+	});
+});
+
 
 // Require other things
 require("./waitfor-cjs");


### PR DESCRIPTION
This allows 3rd parties to pass in additional override functions through
an options object:

```js
var wait = require("can-wait");
var Override = wait.Override;

wait(fn, {
	overrides: [
		function(request){
			return new Override(global, "prop", function(prop){
				return replacement;
			});
		}
	]
});
```

Fixes #25