### PR TITLE
Implements can-wait/ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,28 @@ wait(function(){
 });
 ```
 
+### ignore
+
+Creates a function that, when called, will not track any calls. This might be needed if you are calling code that does unusual things, like using setTimeout recursively indefinitely.
+
+```js
+import ignore from "can-wait/ignore";
+import wait from "can-wait";
+
+wait(function(){
+	function recursive(){
+		setTimeout(function(){
+			recursive();
+		}, 20000);
+	}
+
+	var fn = ignore(recursive);
+
+	// This call will not be waited on.
+	fn();
+});
+```
+
 ### Custom overrides
 
 By default can-wait overrides all of the tasks listed in the [#tasks](Tasks) section, but you might also want to override additional globals. You can do that using the waitOptions object:

--- a/ignore.js
+++ b/ignore.js
@@ -1,0 +1,33 @@
+/**
+ * @module {Function} can-wait/ignore ignore
+ * @parent can-wait
+ *
+ * Allows Ignoring a function, so that any calls out to tasks are ignored and
+ * not part of the normal task flow.
+ *
+ * @signature `ignore(fn)`
+ * @param {Function} fn A function whose calls should be ignored.
+ * @return {Function} A function that will call `fn`, ignoring all calls to
+ * tasks.
+ */
+var ignore = function(fn){
+	return function(){
+		if(!canWaitPresent()) {
+			return fn.apply(this, arguments);
+		}
+		var request = canWait.currentRequest;
+
+		// Use the original versions
+		request.release();
+		var res = fn.apply(this, arguments);
+		request.trap();
+		return res;
+	};
+
+};
+
+function canWaitPresent(){
+	return typeof canWait !== "undefined" && !!canWait.data;
+}
+
+module.exports = ignore;

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -1,0 +1,30 @@
+var assert = require("assert");
+var wait = require("../can-wait");
+var ignore = require("../ignore");
+
+describe("can-wait/ignore", function(){
+	it("allows you to ignore function calls", function(done){
+		function io(){
+			setTimeout(function(){
+
+			}, 20);
+		}
+
+		wait(function(){
+			setTimeout(function(){
+				var fn = ignore(io);
+
+				var request = canWait.currentRequest;
+				assert.equal(request.waits, 1, "Waiting on the currect task");
+				fn();
+				assert.equal(request.waits, 1, "No new waits were added");
+
+				setTimeout(function(){
+					canWait.data("a");
+				}, 30);
+			});
+		}).then(function(responses){
+			assert.equal(responses[0], "a", "calls after the ignored function are handled");
+		}).then(done);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -395,3 +395,4 @@ describe("Options", function(){
 
 // Require other things
 require("./waitfor-cjs");
+require("./ignore");


### PR DESCRIPTION
This implements can-wait/ignore. This allows you to create a function
that, when called, any tasks that are called (like setTimeout, xhr, etc)
	will be ignored. Closes #29