### PR TITLE
can-wait/ignore should work outside of a wait request

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -27,7 +27,7 @@ var ignore = function(fn){
 };
 
 function canWaitPresent(){
-	return typeof canWait !== "undefined" && !!canWait.data;
+	return typeof canWait !== "undefined" && !!canWait.currentRequest;
 }
 
 module.exports = ignore;

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -27,4 +27,12 @@ describe("can-wait/ignore", function(){
 			assert.equal(responses[0], "a", "calls after the ignored function are handled");
 		}).then(done);
 	});
+
+	it("works outside of a request context", function(){
+		var fn = ignore(function(){
+			return "hello";
+		});
+
+		assert.equal(fn(), "hello", "the wrapper works");
+	});
 });


### PR DESCRIPTION
If the page is fully loaded it should still work, but was throwing as it
tried to call `request.release()` when there is no current request.