### PR TITLE
Support calling clearTimeout with an invalid id

### DIFF
--- a/can-wait.js
+++ b/can-wait.js
@@ -91,6 +91,12 @@ var allOverrides = [
 	function(request){
 		return new Override(g, "clearTimeout", function(clearTimeout){
 			return function(timeoutId){
+				// If no timeoutId is passed just call the parent
+				// https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearTimeout#Notes
+				if(timeoutId == null) {
+					return clearTimeout.apply(this, arguments);
+				}
+
 				var ids = request.ids;
 				var id = isNode ? timeoutId.__timeoutId : timeoutId;
 				if(ids[id]) {

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,18 @@ describe("setTimeout", function(){
 				assert.equal(count, 0, "There are no ids outstanding");
 			}
 		});
+
+		it("doesn't throw when passing an invalid timeoutId", function(done){
+			wait(function(){
+				setTimeout(function(){
+					assert.doesNotThrow(function(){
+						clearTimeout();
+					}, "calling clearTimeout with no id works");
+				});
+			}).then(function(){
+				assert.ok(true, "it finished");
+			}).then(done);
+		});
 	});
 });
 


### PR DESCRIPTION
It's possible to call clearTimeout like `clearTimeout()` which is
effectively a noop. This fixes #32