### PR TITLE
Only wrap requestAnimationFrame if defined

### DIFF
--- a/can-wait.js
+++ b/can-wait.js
@@ -110,7 +110,10 @@ var allOverrides = [
 	},
 
 	function(request){
-		return new Override(g, "requestAnimationFrame", function(rAF){
+		return typeof requestAnimationFrame !== "undefined" ?
+			undefined :
+
+		new Override(g, "requestAnimationFrame", function(rAF){
 			return function(fn){
 				var callback = waitWithinRequest(fn);
 				return rAF.call(this, callback);

--- a/test/test.js
+++ b/test/test.js
@@ -208,6 +208,26 @@ if(isBrowser) {
 		});
 
 	});
+} else {
+	describe("requestAnimationFrame", function(){
+		it("doesn't throw", function(done){
+			var raf = global.requestAnimationFrame;
+			global.requestAnimationFrame = function(){
+				console.log("hello");
+			};
+
+			var fn = function(){
+				requestAnimationFrame(function(){});
+			};
+
+			wait(fn).then(function(){
+				global.requestAnimationFrame = raf;
+				done();
+			}, function(errors){
+				done(errors);
+			});
+		});
+	});
 }
 
 describe("Promises", function(){


### PR DESCRIPTION
This handles a scenario where in Node requestAnimationFrame temporarily
exists. The point is that we should only wrap the function if it is
always defined.