### PR TITLE
Do not wrap requestAnimationFrame in Node

### DIFF
--- a/can-wait.js
+++ b/can-wait.js
@@ -110,7 +110,7 @@ var allOverrides = [
 	},
 
 	function(request){
-		return typeof requestAnimationFrame !== "undefined" ?
+		return typeof requestAnimationFrame === "undefined" ?
 			undefined :
 
 		new Override(g, "requestAnimationFrame", function(rAF){

--- a/test/test.js
+++ b/test/test.js
@@ -210,18 +210,12 @@ if(isBrowser) {
 	});
 } else {
 	describe("requestAnimationFrame", function(){
-		it("doesn't throw", function(done){
-			var raf = global.requestAnimationFrame;
-			global.requestAnimationFrame = function(){
-				console.log("hello");
-			};
-
-			var fn = function(){
-				requestAnimationFrame(function(){});
-			};
-
-			wait(fn).then(function(){
-				global.requestAnimationFrame = raf;
+		it("isn't defined", function(done){
+			wait(function(){
+				canWait.data(typeof requestAnimationFrame);
+				setTimeout(function(){});
+			}).then(function(responses){
+				assert.equal(responses[0], "undefined", "there is no rAF in node");
 				done();
 			}, function(errors){
 				done(errors);


### PR DESCRIPTION
This could cause code that tries to detect if rAF exists to get a false
positive and to use it instead of something else (like setTimeout).