### PR TITLE
Allow tasks to be called synchronously

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -16,11 +16,13 @@ var ignore = function(fn){
 			return fn.apply(this, arguments);
 		}
 		var request = canWait.currentRequest;
+		var Task = request.constructor.Task;
 
 		// Use the original versions
-		request.release();
+		var task = new Task(request);
+		task.release();
 		var res = fn.apply(this, arguments);
-		request.trap();
+		task.trap();
 		return res;
 	};
 


### PR DESCRIPTION
This refactors everything a little bit. Before there was only 1 type, a
`Request` that represented the request (or zone) we are observing. I've
added a `Task` type, which represents tasks that are run within the zone
(a task is something like the callback to a setTimeout, or an
 `onreadystatechange` callback).

This made it easier to support synchronously running tasks. We now mark
each task as being "nested" or not. If a task run that then,
	 synchronously, causes another task to run, that second task is
	 considered to be nested. In that case we do not retrap or rerelease
	 the globals, because they are already being trapped by the outer
	 Task.

Fixes #41